### PR TITLE
Remove next/dynamic usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,8 @@ Before any Next.js work, find and read the relevant doc in `node_modules/next/di
 - Implement parallel changes with sub-agents
 - Act as coordinator only
 - Use best model: premium for complex tasks, mid-tier for simple tasks, docs or lookups
-- Grep before read
 - Never read entire dirs. Use find/grep first
-- Tool call cap: stop + explain after 10 tools no progress
+- Tool call cap: stop + explain after 5 tools with no progress
 - Run `npm run sanity-checks` after features
 
 ## TESTING
@@ -38,5 +37,4 @@ Before any Next.js work, find and read the relevant doc in `node_modules/next/di
 
 ## UI DESIGN
 
-- Follow UI design system
-- Design System: @DESIGN.md
+- Strictly follow UI design system: see DESIGN.md file

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,21 +1,102 @@
-# Design System
+---
+name: Portfolio
+description: Mobile-first portfolio website design system.
+colors:
+  primary:
+    light: '#333366'
+    dark: '#d6deff'
+  secondary:
+    light: '#097fa5'
+    dark: '#0ba6d1'
+  background:
+    light: '#ededed'
+    dark: '#121212'
+  backgroundSecondary:
+    light: '#c8dde3'
+    dark: '#1b1b1b'
+  textSecondary:
+    light: '#3c3c3c'
+    dark: '#bbbbbb'
+  button:
+    light: '#097fa5'
+    dark: '#097fa5'
+  buttonText:
+    light: '#fff'
+    dark: '#fff'
+  buttonSecondary:
+    light: '#e7e7e7'
+    dark: '#1d1d1d'
+  dropdown:
+    light: '#e0f4ff'
+    dark: '#2d2d2d'
+  dropdownHover:
+    light: '#b3e5ff'
+    dark: '#454545'
+  selected:
+    light: '#9ec6ff'
+    dark: '#324e70'
+  logoShadow:
+    light: '#053949'
+    dark: '#0a2e36'
+  logoBody:
+    light: '#00d8fe'
+    dark: '#097fa5'
+  spanBg:
+    light: 'linear-gradient(to right, #4e4e9e, #097fa5, #3e87ed)'
+    dark: 'linear-gradient(to right, #8c00ff, #0fb4e1, #a1d930, #ae0000)'
+typography:
+  sans:
+    fontFamily: Noto Sans JP
+spacing:
+  container-padding: 2rem
+---
 
-Mobile first portfolio website. Full i18n support (English/Japanese).
+# Brand & Style
 
-## Stack
+A minimalist, mobile-first portfolio website supporting full i18n (English/Japanese). The visual identity is built to be clean, accessible, and pleasant in both light and dark modes. It utilizes a simplistic but vibrant color scheme, prioritizing readable typography and smooth interactions.
 
-- **Framework:** Next.js App Router + React + TypeScript
-- **i18n:** `next-intl`, routing in `src/i18n/`
-- **Styling:** Tailwind CSS v3. See `src/app/globals.css`
-- **Fonts:** See `src/app/[locale]/layout.tsx`
-- **Dark mode:** `next-themes`, class-based, light default. See `src/app/[locale]/components/Header/ThemeProvider.tsx`
-- **Utilities:** See `src/app/lib`
+## Colors
 
-## Visual Direction
+The application relies on semantic color tokens defined as CSS variables.
 
-- Always mobile first. Scale up for large screens.
-- Visually pleasant in light + dark mode.
+- **Light Theme**: Bright, clean backgrounds (`background`) with contrasting dark text (`primary`).
+- **Dark Theme**: Deep, comfortable dark backgrounds (`background`) with soft, light text (`primary`).
+  Gradients (`spanBg`) are used as energetic accents.
 
-## Accessibility
+## Typography
 
-- Strictly follow a11y web standards
+- **Primary Font**: `Noto Sans JP`. Used as the global `font-sans` family for seamless English and Japanese legibility.
+- **Links**: Displayed with medium weight and underlines that disappear on hover.
+
+## Layout & Spacing
+
+- **Approach**: Strictly mobile-first. Scales up cleanly for larger screens.
+- **Container**: The main wrapper enforces a maximum width constraint and is centered horizontally.
+- **Spacing Guidelines**: Primarily leverages Tailwind CSS default spacing utility scales.
+
+## Elevation & Depth
+
+- The UI primarily utilizes a flat design approach.
+- Shadows are reserved strictly for overlapping floating elements (like dropdown menus or dialogs) using standard Tailwind drop shadows.
+
+## Shapes
+
+- UI elements generally rely on soft default Tailwind rounding.
+
+## Components
+
+- **General Interactions**: Interactive elements should have clearly defined hover and focus states (e.g., links losing underline on hover).
+- **Icons**: Standard interactive target sizes are used to adhere to accessible touch-target requirements.
+
+## Do's and Don'ts
+
+### Do
+
+- Always implement accessibility attributes (`aria-label` or `title`) on icon-only interactive elements for screen readers.
+- Ensure all routing is built with `next-intl`'s `Link` component.
+- Keep the user interface scalable, ensuring horizontal scrolling is avoided on small screens.
+
+### Don't
+
+- Don't use hardcoded color values in component files. Always use the mapped Tailwind variables (e.g., `text-primary`, `bg-background`).
+- Don't mix different font families without a structural reason.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -100,3 +100,4 @@ The application relies on semantic color tokens defined as CSS variables.
 
 - Don't use hardcoded color values in component files. Always use the mapped Tailwind variables (e.g., `text-primary`, `bg-background`).
 - Don't mix different font families without a structural reason.
+- Don't use `animate-in`, `fade-in`, `slide-in-from-*` or similar — these are **not** native Tailwind v3 utilities. Use core classes: `transition-opacity`, `opacity-0/100`, `transition-transform`, `translate-y-*`, `duration-*`, or define custom `@keyframes` in `globals.css`.

--- a/__tests__/config/setup-vitest.ts
+++ b/__tests__/config/setup-vitest.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom/vitest';
+import '../../src/app/[locale]/globals.css';

--- a/__tests__/helpers/app-router-context-provider-mock.tsx
+++ b/__tests__/helpers/app-router-context-provider-mock.tsx
@@ -1,0 +1,52 @@
+/**
+ * Next.js App Router hooks (useRouter, usePathname, useSearchParams) mocks
+ * Allows routing event testing
+ * Adapted from: https://github.com/vercel/next.js/discussions/48937
+ */
+import {
+  AppRouterContext,
+  AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import {
+  PathnameContext,
+  SearchParamsContext,
+} from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import { ReactNode } from 'react';
+import { vi } from 'vitest';
+
+export type AppRouterContextProviderMockProps = {
+  /** Override specific router methods to spy on them in a test */
+  router?: Partial<AppRouterInstance>;
+  /** The current pathname to expose via usePathname() */
+  pathname?: string;
+  /** The current search params to expose via useSearchParams() */
+  searchParams?: URLSearchParams;
+  children: ReactNode;
+};
+
+export const AppRouterContextProviderMock = ({
+  router,
+  pathname = '/',
+  searchParams = new URLSearchParams(),
+  children,
+}: AppRouterContextProviderMockProps): ReactNode => {
+  const mockedRouter: AppRouterInstance = {
+    back: vi.fn(),
+    forward: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+    ...router,
+  };
+
+  return (
+    <PathnameContext.Provider value={pathname}>
+      <SearchParamsContext.Provider value={searchParams}>
+        <AppRouterContext.Provider value={mockedRouter}>
+          {children}
+        </AppRouterContext.Provider>
+      </SearchParamsContext.Provider>
+    </PathnameContext.Provider>
+  );
+};

--- a/__tests__/helpers/intl-provider-mock.tsx
+++ b/__tests__/helpers/intl-provider-mock.tsx
@@ -1,0 +1,24 @@
+/**
+ * Force using English translations in tests by default
+ * instead of cryptic i18n keys
+ */
+import { AbstractIntlMessages, NextIntlClientProvider } from 'next-intl';
+import { ReactNode } from 'react';
+import messages from '@/messages/en.json';
+
+export type IntlProviderMockProps = {
+  locale?: string;
+  children: ReactNode;
+};
+
+export const IntlProviderMock = ({
+  locale = 'en',
+  children,
+}: IntlProviderMockProps): ReactNode => (
+  <NextIntlClientProvider
+    locale={locale}
+    messages={messages as AbstractIntlMessages}
+  >
+    {children}
+  </NextIntlClientProvider>
+);

--- a/__tests__/helpers/testing-library-helpers.tsx
+++ b/__tests__/helpers/testing-library-helpers.tsx
@@ -1,17 +1,22 @@
 import { render } from '@testing-library/react';
-import { AbstractIntlMessages, NextIntlClientProvider } from 'next-intl';
 import { ReactNode } from 'react';
-import messages from '@/messages/en.json';
+import {
+  AppRouterContextProviderMock,
+  AppRouterContextProviderMockProps,
+} from './app-router-context-provider-mock';
+import { IntlProviderMock } from './intl-provider-mock';
 
-export const renderI18n = (children: ReactNode) => {
-  const locale = 'en';
-
-  return render(
-    <NextIntlClientProvider
-      locale={locale}
-      messages={messages as AbstractIntlMessages}
-    >
-      {children}
-    </NextIntlClientProvider>,
-  );
+type RenderI18nOptions = {
+  router?: AppRouterContextProviderMockProps['router'];
+  pathname?: string;
 };
+
+export const renderI18n = (children: ReactNode, options?: RenderI18nOptions) =>
+  render(
+    <AppRouterContextProviderMock
+      router={options?.router}
+      pathname={options?.pathname}
+    >
+      <IntlProviderMock>{children}</IntlProviderMock>
+    </AppRouterContextProviderMock>,
+  );

--- a/__tests__/src/app/[locale]/components/Header.test.tsx
+++ b/__tests__/src/app/[locale]/components/Header.test.tsx
@@ -44,7 +44,7 @@ describe('Header', () => {
     expect(button).toBeInTheDocument();
   });
 
-  test('it should contain a linkedin link', async () => {
+  test('it should contain a LinkedIn link', async () => {
     // given
     const locale = 'en';
 

--- a/__tests__/src/app/[locale]/components/Presentation/Presentation.test.tsx
+++ b/__tests__/src/app/[locale]/components/Presentation/Presentation.test.tsx
@@ -58,7 +58,7 @@ describe('Presentation', () => {
       expect(text).toHaveTextContent('Responsive i18n website');
     });
 
-    test('it should a link to my Github profile', async () => {
+    test('it should contain a link to my Github profile', async () => {
       // when
       renderI18n(<DashboardPage />);
 

--- a/__tests__/src/app/[locale]/page.test.tsx
+++ b/__tests__/src/app/[locale]/page.test.tsx
@@ -4,16 +4,31 @@ import { renderI18n } from '@/__tests__/helpers/testing-library-helpers';
 import DashboardPage from '@/src/app/[locale]/page';
 
 describe('DashboardPage', () => {
-  test('it should only display the presentation at startup', async () => {
+  test('it should show the presentation at startup', async () => {
     // when
-    renderI18n(<DashboardPage />);
+    const { container } = renderI18n(<DashboardPage />);
 
     // then
-    const titles = screen.getAllByRole('heading', {
+    const presentationTitle = screen.getByRole('heading', {
       level: 1,
+      name: "Hi! I'm Stephen",
     });
-    expect(titles).toHaveLength(1);
-    expect(titles[0]).toHaveAccessibleName("Hi! I'm Stephen");
+    expect(presentationTitle).toBeInTheDocument();
+    expect(presentationTitle).toBeVisible();
+  });
+
+  test('it should not show the skills at startup even if present in DOM', async () => {
+    // when
+    const { container } = renderI18n(<DashboardPage />);
+
+    // then
+    const skillSection = screen.getByRole('heading', {
+      level: 1,
+      name: 'Skills',
+      hidden: true,
+    });
+    expect(skillSection).toBeInTheDocument();
+    expect(skillSection).not.toBeVisible();
   });
 
   test('it should contain an arrow image to view more', async () => {
@@ -26,7 +41,7 @@ describe('DashboardPage', () => {
   });
 
   describe('when user clicks to view more arrow down', () => {
-    test('it should load the skills', async () => {
+    test('it should show the skills', async () => {
       // when
       renderI18n(<DashboardPage />);
       fireEvent.click(screen.getByAltText('View more'));
@@ -41,7 +56,7 @@ describe('DashboardPage', () => {
   });
 
   describe('when user clicks the presentation link to load  the skills section', () => {
-    test('it should load the skills', async () => {
+    test('it should show the skills', async () => {
       // when
       renderI18n(<DashboardPage />);
       fireEvent.click(

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-dom": "19.2.7",
         "react-icons": "^5.6.0",
         "tailwind-merge": "^3.6.0",
-        "tailwindcss-animate": "^1.0.7",
         "usehooks-ts": "^3.1.1"
       },
       "devDependencies": {
@@ -67,6 +66,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1408,6 +1408,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1429,6 +1430,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1438,12 +1440,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1617,6 +1621,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1630,6 +1635,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1639,6 +1645,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -4427,12 +4434,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4446,6 +4455,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4458,6 +4468,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4791,6 +4802,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4816,6 +4828,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4921,6 +4934,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4977,6 +4991,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5001,6 +5016,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5048,6 +5064,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5117,6 +5134,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5298,6 +5316,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff": {
@@ -5314,6 +5333,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5484,6 +5504,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6559,6 +6580,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6578,6 +6600,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6615,6 +6638,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6710,6 +6734,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6724,6 +6749,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6854,6 +6880,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6997,6 +7024,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7240,6 +7268,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7292,6 +7321,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -7425,6 +7455,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7793,7 +7824,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8310,6 +8341,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -8322,6 +8354,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8542,6 +8575,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -8551,6 +8585,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -8564,6 +8599,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8629,6 +8665,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -8831,16 +8868,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -8945,6 +8972,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8969,6 +8997,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -9307,6 +9336,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -9338,6 +9368,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9347,6 +9378,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -9413,6 +9445,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -9430,6 +9463,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9451,6 +9485,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9476,6 +9511,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9518,6 +9554,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9543,6 +9580,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -9735,6 +9773,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9792,6 +9831,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -9801,6 +9841,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -9813,6 +9854,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9947,6 +9989,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -9991,6 +10034,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10556,6 +10600,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -10591,6 +10636,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10636,6 +10682,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -10669,19 +10716,11 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
-    },
     "node_modules/tailwindcss/node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -10698,6 +10737,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -10710,6 +10750,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -10719,6 +10760,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10754,6 +10796,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -10763,6 +10806,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -10792,6 +10836,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10838,6 +10883,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10899,6 +10945,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -11232,6 +11279,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -11620,7 +11668,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-dom": "19.2.7",
     "react-icons": "^5.6.0",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.1"
   },
   "devDependencies": {

--- a/src/app/[locale]/components/DashboardPage/Presentation/Presentation.tsx
+++ b/src/app/[locale]/components/DashboardPage/Presentation/Presentation.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { ReactNode } from 'react';
 import { Card } from './Card';
@@ -7,13 +6,16 @@ import { CardText } from './CardText';
 import { CardTitle } from './CardTitle';
 import githubMark from '@/public/github-mark.svg';
 import photo from '@/public/img-profile.jpg';
+import { Link } from '@/src/i18n/routing';
 
 interface PresentationProps {
   className?: string;
+  onLoadMore?: () => void;
 }
 
 export default function Presentation({
   className,
+  onLoadMore,
 }: PresentationProps): ReactNode {
   const t = useTranslations('Dashboard.Presentation');
   return (
@@ -42,7 +44,13 @@ export default function Presentation({
             <CardText
               text={t.rich('profileText', {
                 readmore: (chunks) => (
-                  <Link passHref replace={true} scroll={true} href='#skills'>
+                  <Link
+                    passHref
+                    replace={true}
+                    scroll={false}
+                    href='/skills'
+                    onClick={onLoadMore}
+                  >
                     {chunks}
                   </Link>
                 ),

--- a/src/app/[locale]/components/DashboardPage/Skills/Skills.tsx
+++ b/src/app/[locale]/components/DashboardPage/Skills/Skills.tsx
@@ -4,12 +4,17 @@ import { SkillDescription } from './SkillDescription';
 import { SkillList } from './SkillList';
 import { SkillTerm } from './SkillTerm';
 import { SkillTitle } from './SkillTitle';
+import { cn } from '@/src/app/lib/utils';
 
-export default function Skills(): ReactNode {
+interface SkillsProps {
+  className?: string;
+}
+
+export default function Skills({ className }: SkillsProps): ReactNode {
   const t = useTranslations('Dashboard.Skills');
 
   return (
-    <section id='skills' className='pb-5 sm:px-5'>
+    <section id='skills' className={cn('pb-5 sm:px-5', className)}>
       <h1 className='pt-5 text-4xl font-extrabold leading-tight'>
         {t('title')}
       </h1>

--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -62,3 +62,18 @@
     @apply bg-background text-primary;
   }
 }
+
+@layer utilities {
+  .animate-fade-in {
+    animation: fade-in 0.7s ease-in-out forwards;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -50,6 +50,7 @@ export default function RootLayout(props: {
       lang={locale}
       dir={'ltr'}
       className={cn(notoSansJP.variable, 'font-sans', 'h-full scroll-smooth')}
+      data-scroll-behavior='smooth'
       suppressHydrationWarning
     >
       <body className='max-w-(--breakpoint-2xl) m-auto flex h-full w-full flex-col overflow-auto bg-background text-primary'>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -58,7 +58,7 @@ export default function DashboardPage(): ReactNode {
           </div>
         </Link>
       </div>
-      {loadMore && <Skills />}
+      <Skills className={loadMore ? 'animate-fade-in' : 'hidden'} />
     </>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,26 +1,26 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useEffect, useState } from 'react';
 import Presentation from './components/DashboardPage/Presentation/Presentation';
 import Skills from './components/DashboardPage/Skills/Skills';
 import arrowDown from '@/public/arrow-down.svg';
+import { Link, usePathname, useRouter } from '@/src/i18n/routing';
 
 export default function DashboardPage(): ReactNode {
-  const [loadMore, setLoadMore] = useState(false);
-  const onLoadMore = (): void => setLoadMore(true);
+  const pathname = usePathname();
+  const router = useRouter();
+  const [loadMore, setLoadMore] = useState(pathname === '/skills');
 
-  const params = useSearchParams();
-
-  useEffect(() => {
-    if (window?.location?.hash === '#skills') {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+  const onLoadMore = (): void => {
+    if (!loadMore) {
       setLoadMore(true);
+      if (pathname !== '/skills') {
+        router.replace('/skills', { scroll: false });
+      }
     }
-  }, [params]);
+  };
 
   useEffect(() => {
     if (loadMore) {
@@ -41,8 +41,8 @@ export default function DashboardPage(): ReactNode {
         onWheel={onLoadMore}
         onTouchMove={onLoadMore}
       >
-        <Presentation className='flex-auto' />
-        <Link href='#skills' title={t('viewMoreAlt')}>
+        <Presentation className='flex-auto' onLoadMore={onLoadMore} />
+        <Link href='/skills' scroll={false} title={t('viewMoreAlt')}>
           <div className='sm:h-15 sm:w-15 relative left-1/2 mt-8 h-14 w-14 pb-4 dark:invert'>
             <Image
               src={arrowDown}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,33 +1,13 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useEffect, useState } from 'react';
 import Presentation from './components/DashboardPage/Presentation/Presentation';
+import Skills from './components/DashboardPage/Skills/Skills';
 import arrowDown from '@/public/arrow-down.svg';
-
-const LoadingComponent = () => {
-  const t = useTranslations('Dashboard');
-  return <p className='m-auto my-4 text-center font-bold'>{t('loading')}</p>;
-};
-
-const DynamicSkills = dynamic(
-  () =>
-    import('./components/DashboardPage/Skills/Skills').then((mod) => {
-      setTimeout(() => {
-        const element = document.getElementById('skills');
-        element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }, 500);
-
-      return mod.default;
-    }),
-  {
-    loading: () => <LoadingComponent />,
-  },
-);
 
 export default function DashboardPage(): ReactNode {
   const [loadMore, setLoadMore] = useState(false);
@@ -41,6 +21,16 @@ export default function DashboardPage(): ReactNode {
       setLoadMore(true);
     }
   }, [params]);
+
+  useEffect(() => {
+    if (loadMore) {
+      const timer = setTimeout(() => {
+        const element = document.getElementById('skills');
+        element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [loadMore]);
 
   const t = useTranslations('Dashboard');
 
@@ -68,7 +58,7 @@ export default function DashboardPage(): ReactNode {
           </div>
         </Link>
       </div>
-      {loadMore && <DynamicSkills />}
+      {loadMore && <Skills />}
     </>
   );
 }

--- a/src/app/[locale]/skills/page.tsx
+++ b/src/app/[locale]/skills/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../page';

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,17 +1,32 @@
 import type { MetadataRoute } from 'next';
+import { routing } from '../i18n/routing';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    {
-      url: `${process.env.APP_PUBLIC_URI}`,
-      lastModified: new Date(),
-      priority: 1,
-      alternates: {
-        languages: {
-          es: `${process.env.APP_PUBLIC_URI}/en`,
-          de: `${process.env.APP_PUBLIC_URI}/ja`,
-        },
-      },
+const ROUTES = ['', '/skills'];
+
+const _getPublicUri = (): string => {
+  if (!process.env.APP_PUBLIC_URI) {
+    throw new Error('APP_PUBLIC_URI env var is not set');
+  }
+  return process.env.APP_PUBLIC_URI;
+};
+
+const buildAlternates = (path: string) => {
+  const baseUrl = _getPublicUri();
+  return Object.fromEntries(
+    routing.locales.map((locale) => [locale, `${baseUrl}/${locale}${path}`]),
+  );
+};
+
+const sitemap = (): MetadataRoute.Sitemap => {
+  const baseUrl = _getPublicUri();
+  return ROUTES.map((path, index) => ({
+    url: `${baseUrl}/en${path}`,
+    lastModified: new Date(),
+    priority: index === 0 ? 1 : 0.8,
+    alternates: {
+      languages: buildAlternates(path),
     },
-  ];
-}
+  }));
+};
+
+export default sitemap;

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -10,4 +10,4 @@ export const routing = defineRouting({
   localeDetection: true,
 });
 
-export const { Link, usePathname } = createNavigation(routing);
+export const { Link, usePathname, useRouter } = createNavigation(routing);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,4 @@
 import type { Config } from 'tailwindcss';
-import tailwindAnimate from 'tailwindcss-animate';
 
 const config = {
   darkMode: ['class'],
@@ -48,7 +47,7 @@ const config = {
       },
     },
   },
-  plugins: [tailwindAnimate],
+  plugins: [],
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
# Problem solved

This fixes and closes #6 

# Proposition

- Fix SEO problem by removing netx/dynamic using, and have the skills as not displayed section until users asks for it
  - now the SEO bot crawlers will see the skill content (before : no because they do not trigger user interactions)
-  The skills are now under a url, making also possible to access it directly and have it as part of the sitemap
  - Yet I kept the "one page" animation as it is (I like it that way)
  - No changes to other previous behaviors (scrolling, view more...)

## Side quests

- Includes the suggested Next fix regarding smooth scrolling warning in console

# Remarks

⚠️ Updated the sitemap.xml and detected that it had already issues 😅 

# Test it

- `/en/skills` must now display what lied in prod under `/en#skills` (anchor to path)
- preview must behave the same way as prod
- preview display well in older browsers (BrowserStack)
- browser source must show that skills are in HTML when accessing base url
  - note after prod deployment, google search console test will be needed to confirm better SEO 